### PR TITLE
Add minification to the vulcanization process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -238,6 +238,12 @@ gulp.task('vulcanize', function() {
       inlineCss: true,
       inlineScripts: true
     }))
+    .pipe(htmlmin({
+      collapseWhitespace: true,
+      conservativeCollapse: true,
+      minifyJS: true,
+      minifyCSS: true
+    }))
     .pipe(gulp.dest(dist('elements')))
     .pipe($.size({title: 'vulcanize'}));
 });


### PR DESCRIPTION
Adding minification to the vulcanization process takes elements.html down from ~1.1MB to ~760KB. It makes some sense to minimize here since the elements are what need it the most.
